### PR TITLE
Use a Context object instead of a map of parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ like this:
 r.HandleFunc("/people/{id}", showPerson)
 ```
 
-And the path `/people/123` is triggered, then the parameters passed into peopleCtrl.Show
-would look like the following:
+And the path `/people/123` is triggered, then the parameters passed into the showPerson
+function would look like the following:
 
 ```go
 context.Params = map[string]string{

--- a/README.md
+++ b/README.md
@@ -73,14 +73,29 @@ The second argument to HandleFunc should be a router.Handler, which has the foll
 definition:
 
 ```go
-type Handler func(params map[string]string)
+type Handler func(context *Context)
 ```
 
-So a router.Handler is any function which takes a map of string to string as an argument.
+And the Context type is defined as follows:
+
+```go
+type Context struct {
+	// Params is the parameters from the url as a map of names to values.
+	Params map[string]string
+	// Path is the path that triggered this particular route. If the hash
+	// fallback is being used, the value of path does not include the '#'
+	// symbol.
+	Path string
+	// InitialLoad is true iff this route was triggered during the initial
+	// page load. I.e. it is true if this is the first path that the browser
+	// was visiting when the javascript finished loading.
+	InitialLoad bool
+}
+```
 
 ### Accessing Parameters
 
-Parameters are accessed via the argument to router.Handlers. If we have a route defined
+Parameters are accessed via `context.Params`. If we have a route defined
 like this:
 
 ```go
@@ -91,7 +106,7 @@ And the path `/people/123` is triggered, then the parameters passed into peopleC
 would look like the following:
 
 ```go
-params = map[string]string{
+context.Params = map[string]string{
 	"id": "123",
 }
 ```
@@ -99,8 +114,8 @@ params = map[string]string{
 In our showPerson function, we could access the id parameter like so:
 
 ```go
-func showPerson(params map[string]string) {
-	id := params["id"]
+func showPerson(context *router.Context) {
+	id := context.Params["id"]
 	// ...
 }
 ```

--- a/example_test.go
+++ b/example_test.go
@@ -14,10 +14,10 @@ func ExampleRouter_HandleFunc() {
 	// Create a new Router object
 	r := router.New()
 	// Use HandleFunc to add routes.
-	r.HandleFunc("/greet/{name}", func(params map[string]string) {
+	r.HandleFunc("/greet/{name}", func(context *router.Context) {
 		// The handler for this route simply grabs the name parameter
 		// from the map of params and says hello.
-		fmt.Printf("Hello, %s\n", params["name"])
+		fmt.Printf("Hello, %s\n", context.Params["name"])
 	})
 	// You must call Start in order to start listening for changes
 	// in the url and trigger the appropriate handler function.

--- a/karma/go/router_test.go
+++ b/karma/go/router_test.go
@@ -153,10 +153,10 @@ func main() {
 // given routeChan. This serves as an easy way for us to test which routes were
 // triggered and what params were provided.
 func newChanHandlerFunc(path string, routeChan chan route) router.Handler {
-	return func(params map[string]string) {
+	return func(context *router.Context) {
 		routeChan <- route{
 			path:   path,
-			params: params,
+			params: context.Params,
 		}
 	}
 }

--- a/router.go
+++ b/router.go
@@ -54,14 +54,24 @@ type Router struct {
 	listener func(*js.Object)
 }
 
+// Context is used as an argument to Handlers
 type Context struct {
-	Params      map[string]string
-	Path        string
+	// Params is the parameters from the url as a map of names to values.
+	Params map[string]string
+	// Path is the path that triggered this particular route. If the hash
+	// fallback is being used, the value of path does not include the '#'
+	// symbol.
+	Path string
+	// InitialLoad is true iff this route was triggered during the initial
+	// page load. I.e. it is true if this is the first path that the browser
+	// was visiting when the javascript finished loading.
 	InitialLoad bool
 }
 
 // Handler is a function which is run in response to a specific
-// route. A Handler takes the path parameters as an argument.
+// route. A Handler takes a Context as an argument, which gives
+// handler functions access to path parameters and other important
+// information.
 type Handler func(context *Context)
 
 // New creates and returns a new router
@@ -224,7 +234,7 @@ func (r *Router) setInitialHash() {
 }
 
 // pathChanged should be called whenever the path changes and will trigger
-// the appropriate handler. initial should be true if this is the first
+// the appropriate handler. initial should be true iff this is the first
 // time the javascript is loaded on the page.
 func (r *Router) pathChanged(path string, initial bool) {
 	bestRoute, tokens := r.findBestRoute(path)

--- a/router_test.go
+++ b/router_test.go
@@ -86,7 +86,7 @@ func TestRouter(t *testing.T) {
 			handler := generateTestHandler(path, &gotPath, &gotParams)
 			r.HandleFunc(path, handler)
 		}
-		r.pathChanged(tc.path)
+		r.pathChanged(tc.path, false)
 		if gotPath != tc.expectedPath {
 			t.Errorf("Failed for path=%s. Expected path: %s, Got path: %s", tc.path, tc.expectedPath, gotPath)
 		}
@@ -99,9 +99,9 @@ func TestRouter(t *testing.T) {
 }
 
 func generateTestHandler(path string, gotPath *string, gotParams *map[string]string) Handler {
-	return func(params map[string]string) {
+	return func(context *Context) {
 		*gotPath = path
-		*gotParams = params
+		*gotParams = context.Params
 	}
 }
 


### PR DESCRIPTION
Instead of a `map[string]string` passed into Handlers, I've implemented `Context` which provides additional information.
