### PR TITLE
Make pattern matching regex more inclusive

### DIFF
--- a/router.go
+++ b/router.go
@@ -121,7 +121,7 @@ func newRoute(path string, handler Handler) *route {
 	for _, str := range strs {
 		if str[0] == '{' && str[len(str)-1] == '}' {
 			pattern += `/`
-			pattern += `([\w+-]*)`
+			pattern += `([^/]*)`
 			route.paramNames = append(route.paramNames, str[1:(len(str)-1)])
 		} else {
 			pattern += `/`

--- a/router_test.go
+++ b/router_test.go
@@ -75,6 +75,35 @@ var routeTestCases = []struct {
 		expectedPath:   "/home/all",
 		expectedParams: nil,
 	},
+	// Test query param with weird characters
+	{
+		paths:        []string{"/home", "/home/{homeId}", "/about"},
+		path:         "/home/@1.b$",
+		expectedPath: "/home/{homeId}",
+		expectedParams: map[string]string{
+			"homeId": "@1.b$",
+		},
+	},
+	// Test trailing slash after query param in path
+	{
+		paths:        []string{"/home", "/about", "/about/{aboutId}"},
+		path:         "/about/@1.b$/",
+		expectedPath: "/about/{aboutId}",
+		expectedParams: map[string]string{
+			"aboutId": "@1.b$",
+		},
+	},
+	// Test multiple query params
+	{
+		paths:        []string{"/home", "/home/{homeId}", "/about", "/home/{homeId}/image/{imageSize}/{imageType}/jpg"},
+		path:         "/home/@1.b$/image/800^600/%20a+/jpg",
+		expectedPath: "/home/{homeId}/image/{imageSize}/{imageType}/jpg",
+		expectedParams: map[string]string{
+			"homeId":    "@1.b$",
+			"imageSize": "800^600",
+			"imageType": "%20a+",
+		},
+	},
 }
 
 func TestRouter(t *testing.T) {


### PR DESCRIPTION
This is an alternative to #7. I just use `([^/]*)` to match everything up the the next `/`. It seems to work fine, and includes a few tests.