### PR TITLE
Don't include fragment identifier when matching.

### DIFF
--- a/router.go
+++ b/router.go
@@ -261,7 +261,7 @@ func (r *Router) setInitialHash() {
 // the appropriate handler. initial should be true iff this is the first
 // time the javascript is loaded on the page.
 func (r *Router) pathChanged(path string, initial bool) {
-	bestRoute, tokens, params := r.findBestRoute(path)
+	bestRoute, tokens, params := r.findBestRoute(strings.SplitN(path, "#", 2)[0])
 	// If no routes match, we throw console error and no handlers are called
 	if bestRoute == nil {
 		if r.Verbose {

--- a/router_test.go
+++ b/router_test.go
@@ -130,6 +130,20 @@ var routeTestCases = []struct {
 			"qux": []string{"quux"},
 		},
 	},
+	// Test hash URL matching
+	{
+		paths:          []string{"/home", "/about"},
+		path:           "/about#foo",
+		expectedPath:   "/about",
+		expectedParams: nil,
+	},
+	// Test hash URL matching with extra hashes
+	{
+		paths:          []string{"/home", "/about"},
+		path:           "/about#foo#bar",
+		expectedPath:   "/about",
+		expectedParams: nil,
+	},
 }
 
 func TestRouter(t *testing.T) {


### PR DESCRIPTION
I ran into problems with fragment ids causing URLs not to match and it seemed odd to match on them, given the the server doesn't normally see them. 